### PR TITLE
start experimenting with version of refiner that can see bound names

### DIFF
--- a/src/refiner.fun
+++ b/src/refiner.fun
@@ -101,12 +101,13 @@ struct
       Psi'' \ Ren.rclass rho' rcl'
     end
 
-  (* TODO: handle binding in goal telescope properly *)
   fun substState rho (Psi \ evd : state) = 
     let
-      val Psi' = map (mapSnd (substGoal rho)) Psi
+      val rho' = List.foldr (fn ((x, _), rho) => Sym.Env.remove rho x) rho Psi
+      val Psi' = map (mapSnd (substGoal rho')) Psi
+      val evd' = SubstN.ntm rho' evd
     in
-      Psi' \ SubstN.ntm rho evd
+      Psi' \ evd'
     end
 
   fun renState rho (Psi \ evd) = 

--- a/src/refiner.fun
+++ b/src/refiner.fun
@@ -119,6 +119,12 @@ struct
 
   structure Print = 
   struct
+    fun vars xs = 
+      case xs of
+         [] => ""
+       | [x] => Sym.toString x
+       | x :: xs => Sym.toString x ^ "," ^ vars xs
+
     fun tactic tac = 
       case tac of 
          RULE rl => printRule rl
@@ -131,7 +137,7 @@ struct
        | DEBUG msg => "debug(\"" ^ msg ^ "\")"
        | SEQ (mtac1, mtac2) => multitactic mtac1 ^ "; " ^ multitactic mtac2
        | ORELSE (mtac1, mtac2) => "{" ^ multitactic mtac1 ^ "} | {" ^ multitactic mtac2 ^ "}"
-       | BIND (xs, mtac) => multitactic mtac (* TODO *)
+       | BIND (xs, mtac) => "[" ^ vars xs ^ "] <- {" ^ multitactic mtac ^ "}"
 
     and tactics tacs = 
       case tacs of 

--- a/src/refiner.fun
+++ b/src/refiner.fun
@@ -7,8 +7,17 @@ struct
   infix @@
 
   exception todo fun ?e = raise e
+  type name_block = Lf.var list
+  type names = name_block list
 
-  type names = int Lf.Sym.Env.dict
+  fun mapSnd f (x, y) =
+    (x, f y)
+
+  fun popName (names : names) : Lf.var * names = 
+    case names of 
+       [] => (Lf.Sym.new (), [])
+     | [] :: names => mapSnd (fn names' => [] :: names') (popName names)
+     | (x :: xs) :: names => (x, xs :: names)
 
   datatype tactic =
      RULE of rule
@@ -18,26 +27,29 @@ struct
      ALL of tactic
    | EACH of tactic list
    | DEBUG of string
+   | BIND of Rules.Lf.var list * multitactic
    | SEQ of multitactic * multitactic
    | ORELSE of multitactic * multitactic
 
-  (* The refinement machine has four instructions:
+  (* The refinement machine has five instructions:
        1. [MTAC mtac] means "run [mtac] on returned proof state"
        2. [AWAIT (x, mtac, st)] means "wait for [x] to emit a proof state, and merge it with [st], and continue executing with [mtac]"
        3. [PREPEND Psi] means "prepend the subgoals Psi onto the returned proof state"
-       4. [HANDLE cfg] means "in case of an error, restore the machine state [cfg]"
+       4. [POP_NAMES] pops a user-supplied name block off the name supply stack
+       5. [HANDLE cfg] means "in case of an error, restore the machine state [cfg]"
    *)
   datatype instr =
      MTAC of multitactic
    | AWAIT of Lf.var * multitactic * state
    | PREPEND of (Lf.var * goal) list
+   | POP_NAMES
    | HANDLE of machine_multi
 
   withtype stack = instr list
 
-  and machine_focus = {tactic: tactic, goal: goal, stack: stack}
-  and machine_multi = {multitactic: multitactic, state: state, stack: stack}
-  and machine_retn = {state: state, stack: stack}
+  and machine_focus = {tactic: tactic, goal: goal, stack: stack, names: name_block list}
+  and machine_multi = {multitactic: multitactic, state: state, stack: stack, names: name_block list}
+  and machine_retn = {state: state, stack: stack, names: name_block list}
   and machine_throw = {exn: exn, goal: goal, trace: stack, stack: stack} 
 
   (* The refinement machine has four execution states:
@@ -55,29 +67,53 @@ struct
   datatype 'a step = 
      STEP of 'a
    | FINAL of state
-  
+
   fun init tac goal = 
     FOCUS
       {tactic = tac,
        goal = goal,
-       stack = []}
+       stack = [],
+       names = []}
 
   open Lf infix \ \\ `@ ==> -->
-
-  fun mapSnd f (x, y) =
-    (x, f y)
 
   fun cookGoal (Psi \ rcl) = 
     Psi --> rcl
 
-  val cookGoals = 
+  val cookGoals : (var * goal) list -> ctx = 
     List.map (mapSnd cookGoal)
 
-  fun substGoal rho (Psi \ rclass) = 
+  fun substGoal rho (Psi \ rcl) = 
     let
-      val rho' = List.foldr (fn ((x, _), rho) => Sym.Env.remove rho x) rho Psi
+      val cl = SubstN.class rho (Psi --> rcl)
+      val Psi' \ rcl' = Unbind.class cl
+      val (rho', Psi'') = Ren.rebindCtx (List.map #1 Psi) Psi'
     in
-      Psi \ SubstN.rclass rho' rclass
+      Psi'' \ Ren.rclass rho' rcl'
+    end
+
+  fun renGoal rho (Psi \ rcl) = 
+    let
+      val cl = Ren.class rho (Psi --> rcl)
+      val Psi' \ rcl' = Unbind.class cl
+      val (rho', Psi'') = Ren.rebindCtx (List.map #1 Psi) Psi'
+    in
+      Psi'' \ Ren.rclass rho' rcl'
+    end
+
+  (* TODO: handle binding in goal telescope properly *)
+  fun substState rho (Psi \ evd : state) = 
+    let
+      val Psi' = map (mapSnd (substGoal rho)) Psi
+    in
+      Psi' \ SubstN.ntm rho evd
+    end
+
+  fun renState rho (Psi \ evd) = 
+    let
+      val Psi' = map (mapSnd (renGoal rho)) Psi
+    in
+      Psi' \ Ren.ntm rho evd
     end
 
   structure Print = 
@@ -94,6 +130,7 @@ struct
        | DEBUG msg => "debug(\"" ^ msg ^ "\")"
        | SEQ (mtac1, mtac2) => multitactic mtac1 ^ "; " ^ multitactic mtac2
        | ORELSE (mtac1, mtac2) => "{" ^ multitactic mtac1 ^ "} | {" ^ multitactic mtac2 ^ "}"
+       | BIND (xs, mtac) => multitactic mtac (* TODO *)
 
     and tactics tacs = 
       case tacs of 
@@ -101,7 +138,7 @@ struct
        | [tac] => tactic tac 
        | tac :: tacs => tactic tac ^ ", " ^ tactics tacs
     
-    fun state (Psi \ evd) = 
+    fun state (Psi \ evd : state) = 
       Print.ctx (cookGoals Psi)
         ^ "\n   ===>  "
         ^ Print.ntm evd
@@ -110,6 +147,7 @@ struct
       fn MTAC mtac => "{" ^ multitactic mtac ^ "}"
        | AWAIT (x, mtac, st) => "await[" ^ Sym.toString x ^ "]{" ^ multitactic mtac ^ "}"
        | PREPEND Psi => "prepend{" ^ Print.ctx (cookGoals Psi) ^ "}"
+       | POP_NAMES => "pop-names"
        | HANDLE _ => "handler"
 
     fun stack stk = 
@@ -139,51 +177,80 @@ struct
       [(x, goal)] \ eta (x, cookGoal goal)
     end
 
-  fun stepFocus {tactic, goal, stack} : machine step = 
+  fun runRule {ruleName, goal, stack, names} = 
+    let
+      val namesRef = ref names
+      fun fresh () =
+        let
+          val names = !namesRef
+          val (x, names') = popName names
+        in
+          namesRef := names'; x
+        end 
+
+      val state = rule fresh ruleName goal
+    in
+      RETN {state = state, stack = stack, names = !namesRef}
+    end
+    handle exn =>
+      THROW
+        {exn = exn,
+         goal = goal,
+         trace = [],
+         stack = stack}
+
+  fun stepFocus {tactic, goal, stack, names} : machine step = 
     case tactic of 
        RULE rl => 
-         STEP @@
-          (RETN {state = rule rl goal, stack = stack}
-            handle exn =>
-              THROW
-                {exn = exn,
-                goal = goal,
-                trace = [],
-                stack = stack})
+         STEP o runRule @@ 
+           {ruleName = rl,
+            goal = goal,
+            stack = stack,
+            names = names}
+
      | MT mtac =>
          STEP o RETN @@
            {state = goalToState goal,
-            stack = MTAC mtac :: stack}
+            stack = MTAC mtac :: stack,
+            names = names}
 
-  fun stepRetn {state as Psi \ evd, stack} : machine step = 
+  fun stepRetn {state as Psi \ evd, stack, names} : machine step = 
     case stack of 
        MTAC mtac :: stk =>
          STEP o MULTI @@
            {multitactic = mtac,
             state = state,
-            stack = stk}
+            stack = stk,
+            names = names}
 
-     | AWAIT (x, mtac, Psi' \ evd') :: stk =>
+     | AWAIT (x, mtac, state) :: stk =>
        let
          val rhox = Sym.Env.singleton x evd
-         val Psi'' = List.map (fn (X, goal) => (X, substGoal rhox goal)) Psi'
-         val evd'' = SubstN.ntm rhox evd'
        in
          STEP o MULTI @@
            {multitactic = mtac,
-            state = Psi'' \ evd'',
-            stack = PREPEND Psi :: stk}
+            state = substState rhox state,
+            stack = PREPEND Psi :: stk,
+            names = names}
        end
 
      | PREPEND Psi' :: stk =>
          STEP o RETN @@
            {state = Psi' @ Psi \ evd,
-            stack = stk}
+            stack = stk,
+            names = names}
 
      | HANDLE _ :: stk => 
          STEP o RETN @@
            {state = state,
-            stack = stk}
+            stack = stk,
+            names = names}
+
+     | POP_NAMES :: stk => 
+         STEP o RETN @@ 
+           {state = state,
+            stack = stk,
+            names = List.tl names handle _ => []}
 
      | [] => FINAL state
 
@@ -198,7 +265,7 @@ struct
             trace = instr :: trace,
             stack = stk}
 
-  fun debugString msg {state, stack} = 
+  fun debugString msg {state, stack, names} = 
     "[DEBUG] " ^ msg ^ "\n\n"
       ^ "Proof state: \n------------------------------\n"
       ^ Print.state state
@@ -206,11 +273,12 @@ struct
       ^ Print.stack stack
       ^ "\n\n"
 
-  fun stepMulti (multi as {multitactic, state as Psi \ evd, stack}) : machine step =
+
+  fun stepMulti (multi as {multitactic, state as Psi \ evd, stack, names}) : machine step =
     case (Psi, multitactic) of 
        (_, DEBUG msg) =>
        let
-         val retn = {state = state, stack = stack}
+         val retn = {state = state, stack = stack, names = names}
          val debugStr = debugString msg retn
        in 
          print debugStr;
@@ -221,35 +289,48 @@ struct
        STEP o MULTI @@
          {multitactic = mtac1,
           state = state,
-          stack = MTAC mtac2 :: stack}
+          stack = MTAC mtac2 :: stack,
+          names = names}
+
+     | (_, BIND (xs, mtac)) => 
+        STEP o MULTI @@
+          {multitactic = mtac,
+           state = state,
+           stack = POP_NAMES :: stack,
+           names = xs :: names}
 
      | ([], _) =>
        STEP o RETN @@
          {state = state,
-          stack = stack}
+          stack = stack,
+          names = names}
 
      | ((x, goal) :: Psi, ALL tac) =>
        STEP o FOCUS @@
          {tactic = tac,
           goal = goal,
-          stack = AWAIT (x, ALL tac, Psi \ evd) :: stack}
+          stack = AWAIT (x, ALL tac, Psi \ evd) :: stack, 
+          names = names}
 
      | (_, EACH []) =>
        STEP o RETN @@
          {state = state,
-          stack = stack}
+          stack = stack,
+          names = names}
 
      | ((x, goal) :: Psi, EACH (tac :: tacs)) =>
        STEP o FOCUS @@
          {tactic = tac,
           goal = goal,
-          stack = AWAIT (x, EACH tacs, Psi \ evd) :: stack}
+          stack = AWAIT (x, EACH tacs, Psi \ evd) :: stack,
+          names = names}
 
      | (_, ORELSE (mtac1, mtac2)) => 
        STEP o MULTI @@
          {multitactic = mtac1, 
           state = state,
-          stack = HANDLE multi :: stack}
+          stack = HANDLE multi :: stack,
+          names = names}
 
   val step : machine -> machine step = 
     fn FOCUS foc => stepFocus foc

--- a/src/refiner.fun
+++ b/src/refiner.fun
@@ -103,7 +103,7 @@ struct
     val instr = 
       fn MTAC mtac => "{" ^ multitactic mtac ^ "}"
        | AWAIT (x, mtac, st) => "await[" ^ Sym.toString x ^ "]{" ^ multitactic mtac ^ "}"
-       (*| PREPEND Psi => "prepend{" ^ Print.ctx Psi ^ "}"*)
+       | PREPEND Psi => "prepend{" ^ Print.ctx (cookGoals Psi) ^ "}"
        | HANDLE _ => "handler"
 
     fun stack stk = 

--- a/src/refiner.fun
+++ b/src/refiner.fun
@@ -64,15 +64,21 @@ struct
 
   open Lf infix \ \\ `@ ==> -->
 
+  fun mapSnd f (x, y) =
+    (x, f y)
+
   fun cookGoal (Psi \ rcl) = 
     Psi --> rcl
 
-  fun cookGoals Psi = 
-    List.map (fn (x, goal) => (x, cookGoal goal)) Psi
+  val cookGoals = 
+    List.map (mapSnd cookGoal)
 
-  (* TODO: correct *)
   fun substGoal rho (Psi \ rclass) = 
-    Psi \ SubstN.rclass rho rclass
+    let
+      val rho' = List.foldr (fn ((x, _), rho) => Sym.Env.remove rho x) rho Psi
+    in
+      Psi \ SubstN.rclass rho' rclass
+    end
 
   structure Print = 
   struct

--- a/src/refiner.fun
+++ b/src/refiner.fun
@@ -250,7 +250,7 @@ struct
          STEP o RETN @@ 
            {state = state,
             stack = stk,
-            names = List.tl names handle _ => []}
+            names = List.tl names}
 
      | [] => FINAL state
 

--- a/src/refiner.sig
+++ b/src/refiner.sig
@@ -3,9 +3,10 @@ sig
   structure Lf : LF_TYPING
 
   type rule
-  type state = (Lf.var * Lf.class, Lf.ntm) Lf.bind
+  type goal = (Lf.var * Lf.class, Lf.rclass) Lf.bind
+  type state = (Lf.var * goal, Lf.ntm) Lf.bind
 
-  val rule : rule -> Lf.class -> state
+  val rule : rule -> goal -> state
   val printRule : rule -> string
 end
 
@@ -35,6 +36,6 @@ sig
   end
 
   type machine
-  val init : tactic -> Rules.Lf.class -> machine
+  val init : tactic -> Rules.goal -> machine
   val eval : machine -> Rules.state
 end

--- a/src/refiner.sig
+++ b/src/refiner.sig
@@ -5,8 +5,9 @@ sig
   type rule
   type goal = (Lf.var * Lf.class, Lf.rclass) Lf.bind
   type state = (Lf.var * goal, Lf.ntm) Lf.bind
+  type names = unit -> Lf.var
 
-  val rule : rule -> goal -> state
+  val rule : names -> rule -> goal -> state
   val printRule : rule -> string
 end
 
@@ -25,6 +26,7 @@ sig
      ALL of tactic
    | EACH of tactic list
    | DEBUG of string
+   | BIND of Rules.Lf.var list * multitactic
    | SEQ of multitactic * multitactic
    | ORELSE of multitactic * multitactic
 

--- a/test/example.sml
+++ b/test/example.sml
@@ -122,20 +122,26 @@ struct
   fun test () = 
     let
       open Refiner Rules
+
+      (* SEQ is to THEN as kleisli composition is to kleisli extension. *)
       val sequence = List.foldr SEQ (EACH [])
+
+      (* BIND pushes a block of user-chosen names for part of a tactic script; when the 
+         sub-script is finished, this block will be popped. Tactics can eat names from outer 
+         blocks. *)
       val >>> = BIND
       infix >>>
 
-      val ID = EACH []
-
       val x = Sym.named "my-var"
 
+      (* In the following script, we demonstrate sequencing, dynamic name binding, and debugging. 
+         DEBUG prints out the state of the refinement machine at the point where it is executed. *)
       val script =
         sequence 
           [DEBUG "start", [x] >>>
             sequence
               [DEBUG "start",
-               ALL (RULE ARR_I),
+               ALL (RULE ARR_I), (* observe that 'x' is chosen, because we've pushed it into scope *)
                DEBUG "arr/i",
                ALL (RULE NAT_S),
                DEBUG "nat/s",

--- a/test/example.sml
+++ b/test/example.sml
@@ -126,17 +126,21 @@ struct
       val >>> = BIND
       infix >>>
 
-      val x = Sym.named "xwelp"
+      val ID = EACH []
+
+      val x = Sym.named "my-var"
+
       val script =
-        [x] >>>
-        sequence
-          [DEBUG "start",
-           ALL (RULE ARR_I),
-           DEBUG "arr/i",
-           ALL (RULE NAT_S),
-           DEBUG "nat/s",
-           ALL (RULE (HYP x)),
-           DEBUG "hyp"]
+        sequence 
+          [DEBUG "start", [x] >>>
+            sequence
+              [DEBUG "start",
+               ALL (RULE ARR_I),
+               DEBUG "arr/i",
+               ALL (RULE NAT_S),
+               DEBUG "nat/s",
+               ALL (RULE (HYP x)),
+               DEBUG "hyp"]]
 
       val goal = [] \ `(Inh (Arr (Nat, Nat)))
       val machine = init (MT script) goal

--- a/test/example.sml
+++ b/test/example.sml
@@ -91,7 +91,7 @@ struct
     fun NatS (H \ `inh) =
       let
         val C Sg.INH `@ [[] \ C Sg.NAT `@ []] = Unbind.rtm inh
-        val X = Sym.named "X"
+        val X = Sym.new ()
         val Psi = [(X, H \ `(Inh Nat))]
       in
         Psi \ map #1 H \\ Su (X `@ map eta H)
@@ -102,7 +102,7 @@ struct
         val C Sg.INH `@ [[] \ arr] = Unbind.rtm inh
         val C Sg.ARR `@ [[] \ tyA, [] \ tyB] = Unbind.rtm arr
 
-        val X = Sym.named "X"
+        val X = Sym.new ()
 
         val Hx = H @ [(x, [] ==> `(Inh tyA))]
         val Psi = [(X, Hx \ `(Inh tyB))]
@@ -111,7 +111,7 @@ struct
       end
 
     fun rule fresh = 
-      fn NAT_Z => NatZ 
+      fn NAT_Z => NatZ
        | NAT_S => NatS
        | ARR_I => ArrI (fresh ())
        | HYP x => Hyp x


### PR DESCRIPTION
This might be the easiest path toward supporting names in tactic scripts; we would treat proof refinement as a "dirty" activity which can see bound names, rather than trying to trickily keep track of the mapping between user-supplied names and their indices in context.